### PR TITLE
Update to work with later versions of Firefox (up to 114)

### DIFF
--- a/enablelegacy-prefs.js
+++ b/enablelegacy-prefs.js
@@ -2,6 +2,7 @@
 
 pref("general.config.filename", "enablelegacy.cfg");
 pref("general.config.obscure_value", 0);
+pref("general.config.sandbox_enabled", false);
 
 // Do not automatically upgrade legacy add-ons when upgrading the browser.
 // (Note: To avoid unwanted legacy -> WebExtension upgrades,

--- a/enablelegacy.cfg
+++ b/enablelegacy.cfg
@@ -12,21 +12,43 @@ function patchAddonSettings(modulePath) {
     // Note: we read the data from preferences instead of hard-coding a "true", so
     // that by default legacy add-ons are disabled. This enables the user to only
     // enable legacy add-ons for specific Firefox profiles when really needed.
-    var AddonSettings = Object.create(Module.AddonSettings);
+    var AddonSettings;
+
+    if ("lazy" in Module) {
+      AddonSettings = Object.create(Module.lazy.AddonSettings);
+    } else {
+      AddonSettings = Object.create(Module.AddonSettings);
+    }
     XPCOMUtils.defineLazyPreferenceGetter(AddonSettings, "REQUIRE_SIGNING", "xpinstall.signatures.required", false);
     XPCOMUtils.defineLazyPreferenceGetter(AddonSettings, "ALLOW_LEGACY_EXTENSIONS", "extensions.legacy.enabled", true);
+    XPCOMUtils.defineLazyPreferenceGetter(AddonSettings, "LANGPACKS_REQUIRE_SIGNING", "extensions.langpacks.signatures.required", false);
 
-    Module.AddonSettings = AddonSettings;
+    if ("lazy" in Module) {
+      Module.lazy.AddonSettings = AddonSettings;
+    } else {
+      Module.AddonSettings = AddonSettings;
+    }
 }
 
 // This is necessary to allow legacy add-ons via preferences.
-patchAddonSettings("resource://gre/modules/addons/XPIProvider.jsm");
+try {
+  patchAddonSettings("resource://gre/modules/addons/XPIProvider.jsm");
+} catch (e) {
+  // AddonSettings is not in this file starting with Firefox 61,
+  // but it comes back in Firefox 74
+}
+
+try {
+  patchAddonSettings("resource://gre/modules/addons/XPIDatabase.jsm");
+} catch (e) {
+  // AddonSettings is not in this file until Firefox 61
+}
 
 // This override is needed to enable unsigned add-ons via preferences.
 patchAddonSettings("resource://gre/modules/addons/XPIInstall.jsm");
 
 // This override is needed to allow unsigned add-ons to show up without warning in about:addons.
-// (this is UI-only, the add-on isn't actually disabled despite what the UI claims).
+// (this is UI-only, the add-on is not actually disabled despite what the UI claims).
 patchAddonSettings("resource://gre/modules/addons/AddonSettings.jsm");
 
 Components.classes['@mozilla.org/consoleservice;1']


### PR DESCRIPTION
I've tested this from Firefox 60 to Firefox 114.

I know the isn't to is not is pedantic, but VS Code kept screwing up in the apostrophes and it was driving me crazy :)